### PR TITLE
Fix weekend for out of office

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix out of office check for weekends.
+
 ## [0.1.0] - 2021-09-10
 
 ### Added

--- a/controllers/utility.go
+++ b/controllers/utility.go
@@ -58,7 +58,8 @@ func upgradeAnnouncementTimeReached(upgradeTime time.Time) bool {
 }
 
 func outOfOffice(upgradeTime time.Time) bool {
-	if upgradeTime.Day() == 6 || upgradeTime.Day() == 7 {
+	// Saturday or Sunday, see https://pkg.go.dev/time#Weekday
+	if int(upgradeTime.Weekday()) == 6 || int(upgradeTime.Weekday()) == 0 {
 		return true
 	}
 	if upgradeTime.UTC().Hour() <= 7 && upgradeTime.UTC().Hour() >= 16 {


### PR DESCRIPTION
We need to choose weekdays instead of days. Day only presents the date 1 - 31 🤦🏻 . Converting weekday to int and pick 6 for Saturday and 0 for Sunday, see https://pkg.go.dev/time#Weekday.

## Checklist

- [x] Update changelog in CHANGELOG.md.
