### PR TITLE
Use request cluster name, namespace when Get fails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Fix clearing metrics when cluster is deleted or invalid.
+
 ## [0.3.0] - 2021-10-04
 
 ### Added

--- a/controllers/cluster_controller.go
+++ b/controllers/cluster_controller.go
@@ -68,12 +68,12 @@ func (r *ClusterReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 		if apierrors.IsNotFound(err) {
 			// Object not found, return.  Created objects are automatically garbage collected.
 			// For additional cleanup logic use finalizers.
-			UpgradesInfo.WithLabelValues(cluster.Name, cluster.Namespace).Set(0)
+			UpgradesInfo.WithLabelValues(req.Name, req.Namespace).Set(0)
 			return ctrl.Result{}, nil
 		}
 
 		// Error reading the object - requeue the request.
-		UpgradesInfo.WithLabelValues(cluster.Name, cluster.Namespace).Set(-1)
+		UpgradesInfo.WithLabelValues(req.Name, req.Namespace).Set(-1)
 		return ctrl.Result{}, err
 	}
 


### PR DESCRIPTION
If the Cluster was deleted or otherwise can't be retrieved, we can't use fields from it. Use the cluster name and namespace from the request instead.

## Checklist

- [x] Update changelog in CHANGELOG.md.
