### PR TITLE
Added the use of the runtime/default seccomp profile.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Added the use of the runtime/default seccomp profile.
+
 ## [0.6.1] - 2023-01-03
 
 ### Fixed

--- a/helm/upgrade-schedule-operator/templates/deployment.yaml
+++ b/helm/upgrade-schedule-operator/templates/deployment.yaml
@@ -24,6 +24,9 @@ spec:
       securityContext:
         runAsUser: {{ .Values.pod.user.id }}
         runAsGroup: {{ .Values.pod.group.id }}
+        {{- with .Values.podSecurityContext }}
+          {{- . | toYaml | nindent 8 }}
+        {{- end }}
       containers:
       - name: {{ .Chart.Name }}
         image: "{{ .Values.registry.domain }}/{{ .Values.image.name }}:{{ .Values.image.tag }}"
@@ -47,6 +50,10 @@ spec:
             port: 8081
           initialDelaySeconds: 5
           periodSeconds: 10
+        securityContext:
+          {{- with .Values.securityContext }}
+            {{- . | toYaml | nindent 10 }}
+          {{- end }}
         resources:
           requests:
             cpu: 100m

--- a/helm/upgrade-schedule-operator/templates/psp.yaml
+++ b/helm/upgrade-schedule-operator/templates/psp.yaml
@@ -4,6 +4,8 @@ metadata:
   name: {{ include "resource.psp.name" . }}
   labels:
     {{- include "labels.common" . | nindent 4 }}
+  annotations:
+    seccomp.security.alpha.kubernetes.io/allowedProfileNames: 'runtime/default'
 spec:
   privileged: false
   fsGroup:

--- a/helm/upgrade-schedule-operator/values.schema.json
+++ b/helm/upgrade-schedule-operator/values.schema.json
@@ -1,0 +1,91 @@
+{
+    "$schema": "http://json-schema.org/schema#",
+    "type": "object",
+    "properties": {
+        "image": {
+            "type": "object",
+            "properties": {
+                "name": {
+                    "type": "string"
+                },
+                "tag": {
+                    "type": "string"
+                }
+            }
+        },
+        "pod": {
+            "type": "object",
+            "properties": {
+                "group": {
+                    "type": "object",
+                    "properties": {
+                        "id": {
+                            "type": "integer"
+                        }
+                    }
+                },
+                "user": {
+                    "type": "object",
+                    "properties": {
+                        "id": {
+                            "type": "integer"
+                        }
+                    }
+                }
+            }
+        },
+        "podSecurityContext": {
+            "type": "object",
+            "properties": {
+                "seccompProfile": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string"
+                        }
+                    }
+                }
+            }
+        },
+        "project": {
+            "type": "object",
+            "properties": {
+                "branch": {
+                    "type": "string"
+                },
+                "commit": {
+                    "type": "string"
+                }
+            }
+        },
+        "registry": {
+            "type": "object",
+            "properties": {
+                "domain": {
+                    "type": "string"
+                }
+            }
+        },
+        "securityContext": {
+            "type": "object",
+            "properties": {
+                "seccompProfile": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string"
+                        }
+                    }
+                }
+            }
+        },
+        "verticalPodAutoscaler": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean"
+                }
+            }
+        }
+    }
+}

--- a/helm/upgrade-schedule-operator/values.yaml
+++ b/helm/upgrade-schedule-operator/values.yaml
@@ -15,3 +15,13 @@ pod:
 
 verticalPodAutoscaler:
   enabled: true
+
+# Add seccomp to pod security context
+podSecurityContext:
+  seccompProfile:
+    type: RuntimeDefault
+
+# Add seccomp to container security context
+securityContext:
+  seccompProfile:
+    type: RuntimeDefault


### PR DESCRIPTION
I've modified the container and pod securitycontexts to let this application make use of the runtime/default seccomp profile. During testing this did not seem to interrupt any functionality. Please confirm this if possible.
This is done in light of:

https://github.com/giantswarm/roadmap/issues/259

Drop a message on slack if you've got questions.