### PR TITLE
Allow required volume types in PSP

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Allow required volume types in PSP so that pods can be admitted
+
 ## [0.7.0] - 2023-03-31
 
 ### Added

--- a/helm/upgrade-schedule-operator/templates/psp.yaml
+++ b/helm/upgrade-schedule-operator/templates/psp.yaml
@@ -25,6 +25,11 @@ spec:
   supplementalGroups:
     rule: RunAsAny
   allowPrivilegeEscalation: false
+  volumes:
+    # Used directly in deployment
+    - secret
+    # Needed for Kubernetes API access (https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/)
+    - projected
   hostNetwork: false
   hostIPC: false
   hostPID: false


### PR DESCRIPTION
Pods currently fail to be admitted. This fixes it. Same solution as in other operators (such as https://github.com/giantswarm/roadmap/issues/2074).

## Checklist

- [x] Update changelog in CHANGELOG.md.
