### PR TITLE
Remove old monitoring labels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Remove vintage monitoring labels.
+
 ## [0.7.3] - 2023-07-04
 
 ### Fixed

--- a/helm/upgrade-schedule-operator/templates/service.yaml
+++ b/helm/upgrade-schedule-operator/templates/service.yaml
@@ -5,9 +5,6 @@ metadata:
   namespace: {{ include "resource.default.namespace"  . }}
   labels:
     {{- include "labels.common" . | nindent 4 }}
-    giantswarm.io/monitoring: "true"
-  annotations:
-    giantswarm.io/monitoring-port: "8080"
 spec:
   selector:
     {{- include "labels.selector" . | nindent 4 }}


### PR DESCRIPTION
I enabled the servicemonitor but forgot to remove the labels

## Checklist

- [x] Update changelog in CHANGELOG.md.
