### PR TITLE
Add global.podSecurityStandards.enforced value for PSS migration.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Configure `gsoci.azurecr.io` as the default container image registry.
 
+### Added
+
+- Add global.podSecurityStandards.enforced value for PSS migration.
+
 ## [0.8.0] - 2023-07-13
 
 ### Added 

--- a/helm/upgrade-schedule-operator/templates/psp.yaml
+++ b/helm/upgrade-schedule-operator/templates/psp.yaml
@@ -1,3 +1,4 @@
+{{- if not .Values.global.podSecurityStandards.enforced }}
 apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
@@ -33,3 +34,4 @@ spec:
   hostNetwork: false
   hostIPC: false
   hostPID: false
+{{- end }}

--- a/helm/upgrade-schedule-operator/templates/rbac.yaml
+++ b/helm/upgrade-schedule-operator/templates/rbac.yaml
@@ -73,6 +73,7 @@ roleRef:
   name: {{ include "resource.default.name"  . }}
   apiGroup: rbac.authorization.k8s.io
 ---
+{{- if not .Values.global.podSecurityStandards.enforced }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -104,6 +105,7 @@ roleRef:
   name: {{ include "resource.psp.name" . }}
   apiGroup: rbac.authorization.k8s.io
 ---
+{{- end }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:

--- a/helm/upgrade-schedule-operator/values.schema.json
+++ b/helm/upgrade-schedule-operator/values.schema.json
@@ -2,6 +2,19 @@
     "$schema": "http://json-schema.org/schema#",
     "type": "object",
     "properties": {
+        "global": {
+            "type": "object",
+            "properties": {
+                "podSecurityStandards": {
+                    "type": "object",
+                    "properties": {
+                        "enforced": {
+                            "type": "boolean"
+                        }
+                    }
+                }
+            }
+        },
         "image": {
             "type": "object",
             "properties": {

--- a/helm/upgrade-schedule-operator/values.yaml
+++ b/helm/upgrade-schedule-operator/values.yaml
@@ -33,3 +33,7 @@ securityContext:
   capabilities:
     drop:
       - ALL
+
+global:
+  podSecurityStandards:
+    enforced: false


### PR DESCRIPTION
Needed to upgrade vintage mcs to 1.25

## Checklist

- [x] Update changelog in CHANGELOG.md.
