### PR TITLE
Support CAPI clusters

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -60,3 +60,31 @@ workflows:
               ignore: /.*/
             tags:
               only: /^v.*/
+
+      - architect/push-to-app-collection:
+          context: architect
+          name: push-to-capa-app-collection
+          app_name: "upgrade-schedule-operator"
+          app_collection_repo: "capa-app-collection"
+          requires:
+            - push-upgrade-schedule-operator-to-app-catalog
+            - push-to-registries
+          filters:
+            branches:
+              ignore: /.*/
+            tags:
+              only: /^v.*/
+
+      - architect/push-to-app-collection:
+          context: architect
+          name: push-to-capz-app-collection
+          app_name: "upgrade-schedule-operator"
+          app_collection_repo: "capz-app-collection"
+          requires:
+            - push-upgrade-schedule-operator-to-app-catalog
+            - push-to-registries
+          filters:
+            branches:
+              ignore: /.*/
+            tags:
+              only: /^v.*/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Support CAPI clusters.
+
 ## [0.9.0] - 2024-03-27
 
 ### Changed

--- a/controllers/cluster_controller_test.go
+++ b/controllers/cluster_controller_test.go
@@ -225,7 +225,10 @@ func TestClusterController(t *testing.T) {
 
 			if isCAPIProvider(tc.cluster) {
 				cm := &corev1.ConfigMap{}
-				fakeClient.Get(ctx, types.NamespacedName{Name: tc.configMap.GetName(), Namespace: tc.configMap.GetNamespace()}, cm)
+				err = fakeClient.Get(ctx, types.NamespacedName{Name: tc.configMap.GetName(), Namespace: tc.configMap.GetNamespace()}, cm)
+				if err != nil {
+					t.Error(err)
+				}
 				if !strings.Contains(cm.Data["values"], fmt.Sprintf("version: %s", tc.expectedReleaseVersion)) {
 					t.Fatalf("expected release to be %v, got %s", tc.expectedReleaseVersion, cm.Data["values"])
 				}

--- a/controllers/cluster_controller_test.go
+++ b/controllers/cluster_controller_test.go
@@ -206,7 +206,10 @@ func TestClusterController(t *testing.T) {
 			ctx := context.TODO()
 
 			if isCAPIProvider(tc.cluster) {
-				fakeClient.Create(ctx, tc.configMap)
+				err := fakeClient.Create(ctx, tc.configMap)
+				if err != nil {
+					t.Error(err)
+				}
 			}
 
 			_, err := r.Reconcile(ctx, ctrl.Request{NamespacedName: types.NamespacedName{Name: tc.cluster.GetName(), Namespace: tc.cluster.GetNamespace()}})

--- a/controllers/cluster_controller_test.go
+++ b/controllers/cluster_controller_test.go
@@ -2,11 +2,14 @@ package controllers
 
 import (
 	"context"
+	"fmt"
 	"strconv"
 	"strings"
 	"testing"
 
+	"github.com/giantswarm/k8smetadata/pkg/label"
 	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
@@ -35,7 +38,8 @@ func TestClusterController(t *testing.T) {
 		expectedEventTriggered bool
 		annotationsKept        bool
 
-		cluster *capi.Cluster
+		cluster   *capi.Cluster
+		configMap *corev1.ConfigMap
 	}{
 		// event triggered, within office time
 		{
@@ -133,11 +137,64 @@ func TestClusterController(t *testing.T) {
 				},
 			},
 		},
+		{
+			name:                   "case 4",
+			expectedReleaseVersion: "26.0.0",
+			expectedEventTriggered: true,
+			annotationsKept:        false,
+			cluster: &capi.Cluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test3",
+					Namespace: "org-giantswarm",
+					Labels: map[string]string{
+						"cluster.x-k8s.io/cluster-name": "dh82p",
+						"giantswarm.io/cluster":         "dh82p",
+						"giantswarm.io/organization":    "giantswarm",
+						"release.giantswarm.io/version": "25.0.0",
+						label.AppKubernetesName:         "cluster-aws",
+					},
+					Annotations: map[string]string{
+						"alpha.giantswarm.io/update-schedule-target-release": "26.0.0",
+						"alpha.giantswarm.io/update-schedule-target-time":    "31 Jul 24 14:00 UTC",
+					},
+				},
+			},
+			configMap: &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test3-userconfig",
+					Namespace: "org-giantswarm",
+				},
+				Data: map[string]string{
+					"values": `
+					global:
+					  connectivity:
+						availabilityZoneUsageLimit: 3
+						network: {}
+						topology: {}
+					  controlPlane: {}
+					  metadata:
+						description: Franco tests things from the bundle
+						name: franco055
+						organization: giantswarm
+						preventDeletion: false
+					  nodePools:
+						nodepool0:
+						  instanceType: m5.xlarge
+						  maxSize: 10
+						  minSize: 3
+						  rootVolumeSizeGB: 8
+					  providerSpecific: {}
+					  release:
+					  	version: 25.0.0
+					`,
+				},
+			},
+		},
 	}
 
 	for i, tc := range testCases {
 		t.Run(strconv.Itoa(i), func(t *testing.T) {
-
+			t.Log(tc.name)
 			fakeClient := fake.NewClientBuilder().WithScheme(fakeScheme).WithObjects(tc.cluster).Build()
 			fakeRecorder := record.NewFakeRecorder(1)
 			r := &ClusterReconciler{
@@ -147,6 +204,11 @@ func TestClusterController(t *testing.T) {
 				recorder: fakeRecorder,
 			}
 			ctx := context.TODO()
+
+			if isCAPIProvider(tc.cluster) {
+				fakeClient.Create(ctx, tc.configMap)
+			}
+
 			_, err := r.Reconcile(ctx, ctrl.Request{NamespacedName: types.NamespacedName{Name: tc.cluster.GetName(), Namespace: tc.cluster.GetNamespace()}})
 			if err != nil {
 				t.Error(err)
@@ -158,8 +220,16 @@ func TestClusterController(t *testing.T) {
 				t.Error(err)
 			}
 
-			if obj.Labels["release.giantswarm.io/version"] != tc.expectedReleaseVersion {
-				t.Fatalf("expected release.giantswarm.io/version to be %v, got %s", tc.expectedReleaseVersion, obj.Labels["release.giantswarm.io/version"])
+			if isCAPIProvider(tc.cluster) {
+				cm := &corev1.ConfigMap{}
+				fakeClient.Get(ctx, types.NamespacedName{Name: tc.configMap.GetName(), Namespace: tc.configMap.GetNamespace()}, cm)
+				if !strings.Contains(cm.Data["values"], fmt.Sprintf("version: %s", tc.expectedReleaseVersion)) {
+					t.Fatalf("expected release to be %v, got %s", tc.expectedReleaseVersion, cm.Data["values"])
+				}
+			} else {
+				if obj.Labels["release.giantswarm.io/version"] != tc.expectedReleaseVersion {
+					t.Fatalf("expected release.giantswarm.io/version to be %v, got %s", tc.expectedReleaseVersion, obj.Labels["release.giantswarm.io/version"])
+				}
 			}
 
 			if _, exists := obj.Annotations["alpha.giantswarm.io/update-schedule-target-release"]; exists != tc.annotationsKept {

--- a/controllers/utility.go
+++ b/controllers/utility.go
@@ -1,6 +1,7 @@
 package controllers
 
 import (
+	"strings"
 	"time"
 
 	"github.com/blang/semver"
@@ -36,6 +37,18 @@ func timedRequeue(upgradeTime time.Time) reconcile.Result {
 func getClusterReleaseVersionLabel(cluster *clusterv1.Cluster) string {
 	labels := cluster.GetLabels()
 	return labels[label.ReleaseVersion]
+}
+
+func isCAPIProvider(cluster *clusterv1.Cluster) bool {
+	labels := cluster.GetLabels()
+	name, ok := labels[label.AppKubernetesName]
+	if !ok {
+		return false
+	}
+	if strings.Contains(name, "cluster-") {
+		return true
+	}
+	return false
 }
 
 func getClusterUpgradeTimeAnnotation(cluster *clusterv1.Cluster) string {


### PR DESCRIPTION
Towards: https://github.com/giantswarm/roadmap/issues/3588

In case `Cluster` CR contains `app.kubernetes.io/name: cluster-*`, `upgrade-schedule-operator` updates release version of `userconfig` ConfigMap.

It uses the same pattern as in vintage. In case a user wants to update a cluster on a specific daytime, we set annotations of the release version and the time when `upgrade-schedule-operator` should update the cluster.

The only difference is instead of modifying the release label on the Cluster we change the ConfigMap.

## Checklist

- [x] Update changelog in CHANGELOG.md.